### PR TITLE
remove source map files references in packed files

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,9 @@
   "files": [
     "lib/**/*.d.ts",
     "lib/**/*.js",
+    "lib/**/*.js.map",
     "index.d.ts",
+    "index.js.map",
     "index.js"
   ],
   "dependencies": {


### PR DESCRIPTION
Before the change, packaged files include the reference to their map file.
For example, generated index.js file has the following line at the end:
```
//# sourceMappingURL=index.js.map
```
react-scripts (webpack under the hood) produce warnings in the build:
```
Failed to parse source map from 'XXX/node_modules/rdf-data-factory/index.js.map'
file: Error: ENOENT: no such file or directory, open
'XXX/node_modules/rdf-data-factory/index.js.map'
```
Warnings are legit because map files aren't included in the package. I included
.js.map files in the npm package to prevent errors.

Also, I fixed typescript@4.7.4 errors. I'm not sure that's okay. If you'd like to rollback to a specific typescript version, please specify which one.